### PR TITLE
Fix ssa/ass detection in `is_valid_extension_for_subtitle_format

### DIFF
--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -178,7 +178,7 @@ pub fn get_subtitle_format_by_extension(extension: Option<&OsStr>) -> Option<Sub
 pub fn is_valid_extension_for_subtitle_format(extension: Option<&OsStr>, format: SubtitleFormat) -> bool {
     match format {
         SubtitleFormat::SubRip => extension == Some(OsStr::new("srt")),
-        SubtitleFormat::SubStationAlpha => extension == Some(OsStr::new("srt")) || extension == Some(OsStr::new("srt")),
+        SubtitleFormat::SubStationAlpha => extension == Some(OsStr::new("ssa")) || extension == Some(OsStr::new("ass")),
         SubtitleFormat::VobSubIdx => extension == Some(OsStr::new("idx")),
         SubtitleFormat::VobSubSub => extension == Some(OsStr::new("sub")),
         SubtitleFormat::MicroDVD => extension == Some(OsStr::new("sub")),


### PR DESCRIPTION
I was using alass and noticed that ssa/ass files weren't working, inspected the code for alass for a while and found this. (Note that this means a version should probably be cut, and alass should probably be updated)