### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/formats/common.rs
+++ b/src/formats/common.rs
@@ -159,7 +159,7 @@ pub fn get_lines_non_destructive(s: &str) -> Vec<SplittedLine> {
 #[test]
 fn get_lines_non_destructive_test0() {
     let lines = ["", "aaabb", "aaabb\r\nbcccc\n\r\n ", "aaabb\r\nbcccc"];
-    for &full_line in lines.into_iter() {
+    for &full_line in lines.iter() {
         let joined: String = get_lines_non_destructive(full_line)
             .into_iter()
             .flat_map(|(s1, s2)| vec![s1, s2].into_iter())


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
