### PR TITLE
Add missing Timepoint Add (Sub exists)

### DIFF
--- a/src/timetypes.rs
+++ b/src/timetypes.rs
@@ -314,6 +314,7 @@ macro_rules! impl_sub_assign {
 }
 
 impl_add!(TimeDelta, TimeDelta, TimeDelta);
+impl_add!(TimePoint, TimePoint, TimeDelta);
 impl_add!(TimePoint, TimeDelta, TimePoint);
 impl_add!(TimeDelta, TimePoint, TimePoint);
 


### PR DESCRIPTION
Sub for TimePoint exists, but not Add:

```
49 |   let t2 = subtitle_entries[pos+3].timespan.end + TimePoint::from_secs(2);
   |                                                   ^^^^^^^^^^^^^^^^^^^^^^^ expected struct `TimeDelta`, found struct `TimePoint`
```

However we have    `impl Sub<TimeDelta> for TimePoint`, so this works to add:
```
let t2 = subtitle_entries[pos+3].timespan.end - TimePoint::from_secs(-2);
```

This PR adds the Add for TimePoint, so now there is both add and sub.

The crate is awesome, thanks!
